### PR TITLE
refactor: remove the unessasary nested try except blocks

### DIFF
--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -71,11 +71,14 @@ def upload_omamori_picture(picture, uuid: str):
             ExpressionAttributeValues=expression_attribute_values,
             ReturnValues="UPDATED_NEW"
         )
+        return updated_omamori["Attributes"]
     except (ClientError, BotoCoreError) as err:
 
         if ClientError or BotoCoreError:
             deleted_picture = delete_picture_by_object_name(
                 object_name=uploaded_picture_data)
+
+            # TO DO: What to do if the picture was not deleted?
 
             logging.error("Couldn't updated omamori table",
                           "Here's why",
@@ -85,8 +88,6 @@ def upload_omamori_picture(picture, uuid: str):
 
         raise CustomException(field="Upload_omamori_picture",
                               error_code=ErrorCode.SERVER_ERROR, status_code=500)
-
-    return updated_omamori["Attributes"]
 
 
 def map_request_to_db_entity(omamori: OmamoriInput):


### PR DESCRIPTION
# Description

I refactor the way we use the try and catch blocks. Previously it was hard to read.

# Closes issue(s)

Resolves #24 

# How to test
Run the API and make a request
# Changes include

1. Refactor the try and catch block for upload_picture

# Checklist

- [x] I have tested this code
- [ ] I have updated the README