### PR TITLE
refactor: refactor how we raise the errors in update_omamori_picture

### DIFF
--- a/src/db/s3.py
+++ b/src/db/s3.py
@@ -1,6 +1,7 @@
 import boto3
 import logging
 import uuid
+from fastapi import UploadFile
 from botocore.exceptions import ClientError, BotoCoreError
 from src.custom_error import CustomException
 from src.custom_error import ErrorCode
@@ -8,11 +9,11 @@ from src.custom_error import ErrorCode
 logger = logging.getLogger(__name__)
 
 
-def upload_picture(file, bucket='omamori-finder-pictures-development') -> str:
+def upload_picture(img_file: UploadFile, bucket='omamori-finder-pictures-development') -> str:
     try:
         client = boto3.client('s3')
         object_name = f'media/{str(uuid.uuid4())}.jpg'
-        client.upload_fileobj(file.file, bucket, object_name)
+        client.upload_fileobj(img_file.file, bucket, object_name)
         return object_name
     except (ClientError, BotoCoreError) as err:
         logging.error("Was not able to upload the picture to S3 bucket",

--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -42,9 +42,9 @@ def create_omamori(omamori: OmamoriInput):
                               )
 
 
-def upload_omamori_picture(picture: UploadFile, uuid: str):
+def upload_omamori_picture(img_file: UploadFile, uuid: str):
     try:
-        uploaded_picture_data = upload_picture(picture)
+        uploaded_picture_data = upload_picture(img_file)
 
         update_expression = "SET #upload_status = :upload_status, #picture_path = :picture_path, #updated_at = :updated_at"
 


### PR DESCRIPTION
# Description

Previously, the `upload_picture` function returned a value that determined whether an error should be raised. The calling code would then check this value and raise an error if necessary.

In this PR, the error handling has been moved directly into the `upload_picture` function. Errors are now raised within the function itself and handled by the calling code's try-except block.

# Closes issue(s)

Resolves #29 

# How to test

# Changes include

1. Move the raise exception inside upload_picture
2. Add type hint for picture parameter
3. Change the bucket to the development s3 bucket

# Checklist

- [x] I have tested this code
- [x] I have updated the README