### PR TITLE
feat: create string validations for Japanese and Latin characters

### DIFF
--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -8,8 +8,8 @@ from datetime import datetime
 from src.db.s3 import upload_picture, delete_picture_by_object_name
 from src.db.dbInstance import dynamodb
 from src.custom_error import CustomException, ErrorCode
-from src.utils.string_utils import has_special_characters, has_script_tags, has_google_maps_url
-from src.utils.enum_types import UploadStatus
+from src.utils.string_utils import has_special_characters, has_script_tags, has_google_maps_url, has_japanese_characters, has_latin_characters
+from src.utils.enum_types import UploadStatus, LocaleEnum
 
 # primary key is uuid
 
@@ -121,17 +121,28 @@ def validate_create_omamori(omamori: OmamoriInput):
     return validation_error
 
 
-def validate_shrine_name(shrine_name: ShrineName, validation_error: ValidationError):
+def validate_shrine_name(shrine_name: list[ShrineName], validation_error: ValidationError):
 
     if len(shrine_name) < 1:
         validation_error["has_error"] = True
 
     for name in shrine_name:
         if has_special_characters(name.name):
+            validation_error["fieds"].append({
+
+            })
             validation_error["has_error"] = True
 
         if has_script_tags(name.name):
             validation_error["has_error"] = True
+
+        if name.locale == LocaleEnum.en_US:
+            if has_japanese_characters(name.name):
+                validation_error["has_error"] = True
+
+        if name.locale == LocaleEnum.ja_JP:
+            if has_latin_characters(name.name):
+                validation_error["has_error"] = True
 
     return validation_error
 

--- a/src/utils/string_utils.py
+++ b/src/utils/string_utils.py
@@ -34,11 +34,21 @@ def has_google_maps_url(string_value: str) -> bool:
 
 
 def has_japanese_characters(string_value: str) -> bool:
-    regex_japanese_charachters = r"[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]"
+    regex_japanese_characters = r"[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]+"
     contains_japanese_characters = re.search(
-        regex_japanese_charachters, string_value)
+        regex_japanese_characters, string_value)
 
     if contains_japanese_characters == None:
+        return False
+
+    return True
+
+
+def has_latin_characters(string_value: str) -> bool:
+    regex_latin_characters = r"[a-zA-Z]+"
+    contains_latin_characters = re.search(regex_latin_characters, string_value)
+
+    if contains_latin_characters is None:
         return False
 
     return True


### PR DESCRIPTION
# Description

Added string validation for the `shrine_name`  field to ensure the correct language is used in the corresponding field:

- Japanese fields must contain Japanese characters.
- English fields must contain Latin characters.

# Closes issue(s)

Resolves #38 

# How to test

# Changes include

1. Added a function to check if a string contains Japanese characters.
2. Added a function to check if a string contains Latin characters.

# Checklist

- [ ] I have tested this code
- [ ] I have updated the README