### PR TITLE
refactor error handling for create_omamori

### DIFF
--- a/src/custom_error.py
+++ b/src/custom_error.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import TypedDict
-from fastapi import HTTPException, Request, FastAPI
+from fastapi import Request, FastAPI
 from fastapi.responses import JSONResponse
 
 
@@ -17,14 +17,18 @@ class ErrorCode(Enum):
     INVALID_GOOGLE_MAP_URL = "INVALID_GOOGLE_MAP_URL"
 
 
-class Error(TypedDict):
-    errors: list[dict]
-    error: ErrorCode
+class ErrorFieldDetail(TypedDict):
+    field: str
+    error_code: ErrorCode
+
+
+class ErrorResponse(TypedDict):
+    errors: list[ErrorFieldDetail]
     has_error: bool
 
 
 class CustomException(Exception):
-    def __init__(self, error: list[Error], status_code: int) -> None:
+    def __init__(self, error: ErrorResponse, status_code: int) -> None:
         self.error = error
         self.status_code = status_code
 

--- a/src/db/s3.py
+++ b/src/db/s3.py
@@ -23,10 +23,10 @@ def upload_picture(img_file: UploadFile, bucket='omamori-finder-pictures-develop
             error={
                 "errors": [
                     {
-                        "field": "upload_picture"
+                        "field": "upload_picture",
+                        "error_code": ErrorCode.SERVER_ERROR.value,
                     }
                 ],
-                "error": ErrorCode.SERVER_ERROR.value,
                 "has_error": True
             },
             status_code=500

--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -1,7 +1,7 @@
 import logging
 import src.service.omamori_service as service
 from fastapi import APIRouter, UploadFile, Form
-from src.schemas.omamori import OmamoriOut, OmamoriInput, OmamoriPictureOut
+from src.schemas.omamori import OmamoriOut, OmamoriInput
 
 router = APIRouter()
 
@@ -21,6 +21,5 @@ async def create_omamori(omamori: OmamoriInput) -> OmamoriOut:
 @router.post("/uploadpicture")
 async def upload_omamori_picture(picture: UploadFile, uuid: str = Form(...)):
     uploaded_picture = service.upload_omamori_picture(
-        picture=picture, uuid=uuid)
-    print("Uploaded", uploaded_picture)
+        img_file=picture, uuid=uuid)
     return uploaded_picture


### PR DESCRIPTION
# Description

Previously, our error result could not hold multiple errors. For example, during field validations, we could only send back a single error, which made it difficult to communicate all failing fields.

With this PR:

- The error response now supports returning multiple error details.
- This enables us to provide clearer feedback for all failed fields during validation.

# Closes issue(s)

Resolves #41 

# How to test

You can use the following data for a request:

```
{
  "shrine_name": [
    {
      "name": "Meiji Jingu!!!",
      "locale": "en_US"
    },
    {
      "name": "Meiji Jingu",
      "locale": "ja_JP"
    }
  ],
  "google_maps_link": "https://some.weird.url/RAAtiAsSBkA5X2UM6",
  "prefecture": "Hokkaido",
  "protection_type": "happiness",
  "shrine_religion": "Buddhism",
  "description": "string",
  "upload_status": "NOT_STARTED"
}
```

1. This will result in 3 errors
2. Check if you get 3 error details back.

# Changes include

1. Refactored the error result by changing the data type to support multiple errors.
2. Created a new type to represent error details.
3. Updated all functions that return an error to use the new error result format.

# Checklist

- [x] I have tested this code
- [x] I have updated the README