### PR TITLE
feat: Resize images before uploading to S3 bucket

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ markdown-it-py==3.0.0
 MarkupSafe==2.1.5
 mdurl==0.1.2
 orjson==3.10.3
+pillow==11.0.0
 pydantic==2.7.1
 pydantic_core==2.18.2
 Pygments==2.18.0

--- a/src/db/s3.py
+++ b/src/db/s3.py
@@ -1,20 +1,54 @@
 import boto3
 import logging
 import uuid
+from io import BytesIO
+from PIL import Image
 from fastapi import UploadFile
 from botocore.exceptions import ClientError, BotoCoreError
-from src.custom_error import CustomException
-from src.custom_error import ErrorCode
+from src.custom_error import ErrorCode, CustomException
 
 logger = logging.getLogger(__name__)
 
+BUCKET_NAME = "omamori-finder-pictures-development"
 
-def upload_picture(img_file: UploadFile, bucket='omamori-finder-pictures-development') -> str:
+
+def resize_image(image, size: tuple):
     try:
+        with Image.open(image) as im:
+            im.thumbnail(size)
+            buffer = BytesIO()
+            im.save(buffer, "JPEG")
+            buffer.seek(0)
+            return buffer
+    except OSError:
+        print("cannot create thumbnail for", image)
+
+
+def upload_picture(img_file: UploadFile) -> str:
+    try:
+        image_uuid = str(uuid.uuid4())
+
+        image_sizes = {
+            "desktop_size": (1080, 1080),
+            "mobile_size": (640, 640),
+            "mobile_small_size": (300, 300)
+        }
+
         client = boto3.client('s3')
-        object_name = f'media/{str(uuid.uuid4())}.jpg'
-        client.upload_fileobj(img_file.file, bucket, object_name)
-        return object_name
+
+        image_paths = {}
+
+        for type_size, size in image_sizes.items():
+
+            object_name = f'images/{image_uuid}/{type_size}.jpg'
+
+            resized_image = resize_image(image=img_file.file, size=size)
+
+            client.upload_fileobj(resized_image, BUCKET_NAME, object_name)
+
+            image_paths[type_size] = object_name
+
+        return image_paths
     except (ClientError, BotoCoreError) as err:
         logging.error("Was not able to upload the picture to S3 bucket",
                       "Here is why",
@@ -33,11 +67,16 @@ def upload_picture(img_file: UploadFile, bucket='omamori-finder-pictures-develop
         )
 
 
-def delete_picture_by_object_name(object_name: str):
+def delete_picture_by_object_name(object_names: dict):
     client = boto3.client("s3")
     try:
-        response = client.delete_object(
-            Bucket="omamori-finder-pictures-development", Key=object_name)
+        images_to_delete = [{'Key': path} for path in object_names.values()]
+
+        response = client.delete_objects(
+            Bucket=BUCKET_NAME,
+            Delete={'Objects': images_to_delete}
+        )
+
         return response
     except ClientError as err:
         logging.error(err)

--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -53,7 +53,8 @@ def create_omamori(omamori: OmamoriInput):
 
 def upload_omamori_picture(img_file: UploadFile, uuid: str):
     try:
-        uploaded_picture_data = upload_picture(img_file)
+        # TO DO: Before we even attempt to upload a picture we need to check if this uui (omamori) even exist.
+        uploaded_picture_data: dict = upload_picture(img_file)
 
         update_expression = "SET #upload_status = :upload_status, #picture_path = :picture_path, #updated_at = :updated_at"
 
@@ -85,7 +86,7 @@ def upload_omamori_picture(img_file: UploadFile, uuid: str):
 
         if ClientError or BotoCoreError:
             deleted_picture = delete_picture_by_object_name(
-                object_name=uploaded_picture_data)
+                object_names=uploaded_picture_data)
 
             # TO DO: What to do if the picture was not deleted?
 


### PR DESCRIPTION
# Description

Previously, we did not resize pictures before saving them to our S3 bucket. To improve performance and optimize image loading, we now resize pictures before uploading. The images are resized into three different sizes:

- Mobile
- Browser
- Mobile Thumbnail

# Closes issue(s)

Resolves #34 

# How to test

# Changes include

1. Added a function to resize pictures to predefined dimensions.
2. Refactored variable names for better readability and consistency.

# Checklist

- [x] I have tested this code
- [x] I have updated the README