### PR TITLE
feat: add birth and pregnancy protection to ProtectionType Enum 

### DIFF
--- a/src/utils/enum_types.py
+++ b/src/utils/enum_types.py
@@ -27,6 +27,8 @@ class ProtectionTypeEnum(str, Enum):
     health = "health"
     success = "success"
     family = "family"
+    pregnancy = "pregnancy"
+    safe_birth = "safe birth"
 
 
 class PrefectureEnum(str, Enum):


### PR DESCRIPTION
# Description

Previously we didn't include protection types that had to do with pregnancy and birth, but they are quite common as omamori. In this PR I just have added birth and pregnancy to the protectionType enum.

# Closes issue(s)

Resolves #4 

# How to test

# Changes include

1. Add protection types to ProtectionType enum

# Checklist

- [x] I have tested this code
- [x] I have updated the README