### PR TITLE
feat: add search functionality to our service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,22 +37,13 @@ stopcontainer:
 	docker compose down
 
 createtable:
-	@echo "Creating table in dynamodb"
+	@echo "👷Creating table in dynamodb👷"
 	AWS_ACCESS_KEY_ID=X AWS_SECRET_ACCESS_KEY=X aws dynamodb create-table \
-	--endpoint-url http://localhost:8000 \
-	--table-name omamori \
-	--attribute-definitions \
-		AttributeName=uuid,AttributeType=S \
-		AttributeName=prefecture,AttributeType=S \
-		AttributeName=protection_type,AttributeType=S \
-		AttributeName=shrine_religion,AttributeType=S \
-	--key-schema \
-		AttributeName=uuid,KeyType=HASH \
-		AttributeName=prefecture,KeyType=RANGE \
-	--global-secondary-indexes \
-		'[{"IndexName": "prefecture_index","KeySchema": [{"AttributeName": "prefecture", "KeyType": "HASH"},{"AttributeName": "protection_type", "KeyType": "RANGE"}],"Projection": {"ProjectionType": "ALL"},"ProvisionedThroughput": {"ReadCapacityUnits": 10,"WriteCapacityUnits": 5}}]' \
-	--billing-mode PAY_PER_REQUEST --region localhost
+	--cli-input-json file://omamori_table_definition.json \
+	--region localhost \
+	--endpoint-url http://localhost:8000
 
+# {"AttributeName": "protection_type", "KeyType": "RANGE"} needs be a sort key so It need to be unique
 activate: venv
 	$(BIN)
 

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,18 @@ createtable:
 	@echo "Creating table in dynamodb"
 	AWS_ACCESS_KEY_ID=X AWS_SECRET_ACCESS_KEY=X aws dynamodb create-table \
 	--endpoint-url http://localhost:8000 \
-	--table-name omamori --attribute-definitions AttributeName=uuid,AttributeType=S \
-	--key-schema AttributeName=uuid,KeyType=HASH --billing-mode PAY_PER_REQUEST  --region localhost
+	--table-name omamori \
+	--attribute-definitions \
+		AttributeName=uuid,AttributeType=S \
+		AttributeName=prefecture,AttributeType=S \
+		AttributeName=protection_type,AttributeType=S \
+		AttributeName=shrine_religion,AttributeType=S \
+	--key-schema \
+		AttributeName=uuid,KeyType=HASH \
+		AttributeName=prefecture,KeyType=RANGE \
+	--global-secondary-indexes \
+		'[{"IndexName": "prefecture_index","KeySchema": [{"AttributeName": "prefecture", "KeyType": "HASH"},{"AttributeName": "protection_type", "KeyType": "RANGE"}],"Projection": {"ProjectionType": "ALL"},"ProvisionedThroughput": {"ReadCapacityUnits": 10,"WriteCapacityUnits": 5}}]' \
+	--billing-mode PAY_PER_REQUEST --region localhost
 
 activate: venv
 	$(BIN)

--- a/omamori_table_definition.json
+++ b/omamori_table_definition.json
@@ -1,0 +1,51 @@
+{
+    "TableName": "omamori_data",
+    "KeySchema": [ 
+       { 
+          "AttributeName": "uuid",
+          "KeyType": "HASH"
+       },
+       { 
+          "AttributeName": "prefecture",
+          "KeyType": "RANGE"
+       }
+    ],
+    "AttributeDefinitions": [ 
+        { 
+            "AttributeName": "uuid",
+            "AttributeType": "S"
+        },
+        { 
+            "AttributeName": "prefecture",
+            "AttributeType": "S"
+        }
+    ],
+    "BillingMode": "PAY_PER_REQUEST",
+    "GlobalSecondaryIndexes": [ 
+       { 
+          "IndexName": "prefecture_index",
+          "KeySchema": [ 
+             { 
+                "AttributeName": "prefecture",
+                "KeyType": "HASH"
+             },
+             { 
+                "AttributeName": "uuid",
+                "KeyType": "RANGE"
+             }
+          ],
+          "Projection": { 
+             "NonKeyAttributes": [
+                "protection_type",
+                "google_maps_link",
+                "description",
+                "shrine_name",
+                "shrine_religion",
+                "picture_path"
+              ],
+             "ProjectionType": "INCLUDE"
+          }
+       }
+    ]
+ }
+ 

--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -11,9 +11,9 @@ router = APIRouter()
 async def get_omamori(
     prefecture: PrefectureEnum | None = None,
     protection: ProtectionTypeEnum | None = None,
-    religion: ShrineReligionEnum | None = None
 ):
-    omamoris_by_prefecture = service.get_omamori(prefecture=prefecture)
+    omamoris_by_prefecture = service.get_omamori(
+        prefecture=prefecture, protection=protection)
     return omamoris_by_prefecture
 
 

--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -2,7 +2,7 @@ import logging
 import src.service.omamori_service as service
 from fastapi import APIRouter, UploadFile, Form
 from src.schemas.omamori import OmamoriOut, OmamoriInput, OmamoriSearchResults
-from src.utils.enum_types import PrefectureEnum, ProtectionTypeEnum, ShrineReligionEnum
+from src.utils.enum_types import PrefectureEnum, ProtectionTypeEnum
 
 router = APIRouter()
 

--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -13,8 +13,8 @@ async def get_omamori(
     protection: ProtectionTypeEnum | None = None,
     religion: ShrineReligionEnum | None = None
 ):
-    print("Filters are", prefecture, protection, religion)
-    return {"Here are some omamori 🎏"}
+    omamoris_by_prefecture = service.get_omamori(prefecture=prefecture)
+    return omamoris_by_prefecture
 
 
 @router.post("/omamori")

--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -1,18 +1,18 @@
 import logging
 import src.service.omamori_service as service
 from fastapi import APIRouter, UploadFile, Form
-from src.schemas.omamori import OmamoriOut, OmamoriInput
+from src.schemas.omamori import OmamoriOut, OmamoriInput, OmamoriSearchResults
 from src.utils.enum_types import PrefectureEnum, ProtectionTypeEnum, ShrineReligionEnum
 
 router = APIRouter()
 
 
 @router.get("/omamori/")
-async def get_omamori(
+async def search_omamori(
     prefecture: PrefectureEnum | None = None,
     protection: ProtectionTypeEnum | None = None,
-):
-    omamoris_by_prefecture = service.get_omamori(
+) -> list[OmamoriSearchResults]:
+    omamoris_by_prefecture = service.search_omamori(
         prefecture=prefecture, protection=protection)
     return omamoris_by_prefecture
 

--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -2,12 +2,18 @@ import logging
 import src.service.omamori_service as service
 from fastapi import APIRouter, UploadFile, Form
 from src.schemas.omamori import OmamoriOut, OmamoriInput
+from src.utils.enum_types import PrefectureEnum, ProtectionTypeEnum, ShrineReligionEnum
 
 router = APIRouter()
 
 
-@router.get("/omamori")
-async def get_omamori():
+@router.get("/omamori/")
+async def get_omamori(
+    prefecture: PrefectureEnum | None = None,
+    protection: ProtectionTypeEnum | None = None,
+    religion: ShrineReligionEnum | None = None
+):
+    print("Filters are", prefecture, protection, religion)
     return {"Here are some omamori 🎏"}
 
 

--- a/src/schemas/omamori.py
+++ b/src/schemas/omamori.py
@@ -34,3 +34,7 @@ class OmamoriInput(BaseModel):
     shrine_religion: ShrineReligionEnum
     description: str | None = None
     upload_status: UploadStatus | None = UploadStatus.NOT_STARTED
+
+
+class OmamoriSearchResults(OmamoriInput):
+    _upload_status: UploadStatus | None = UploadStatus.NOT_STARTED

--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -2,7 +2,6 @@ import logging
 import uuid
 from fastapi import UploadFile
 from botocore.exceptions import ClientError, BotoCoreError
-from boto3.dynamodb.conditions import Key
 from src.schemas.omamori import OmamoriInput, ShrineName, OmamoriSearchResults
 from datetime import datetime
 from src.db.s3 import upload_picture, delete_picture_by_object_name

--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -17,17 +17,22 @@ from src.utils.string_utils import (
 )
 from src.utils.enum_types import UploadStatus, LocaleEnum
 
-# primary key is uuid
-
-omamori_table = dynamodb.Table("omamori")
+omamori_table = dynamodb.Table("omamori_data")
 
 
-def get_omamori(prefecture: str):
+def get_omamori(prefecture: str, protection: str):
     try:
+        expression_attributes_values = ""
+
+        if prefecture:
+            expression_attributes_values = {
+                ":prefecture_val": prefecture.value
+            }
+
         items_by_prefecture = omamori_table.query(
             IndexName="prefecture_index",
-            Select="ALL_ATTRIBUTES",
-            KeyConditionExpression=Key("prefecture").eq(prefecture)
+            KeyConditionExpression="prefecture = :prefecture_val",
+            ExpressionAttributeValues=expression_attributes_values
         )
         return items_by_prefecture["Items"]
     except Exception as e:

--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from fastapi import UploadFile
 from botocore.exceptions import ClientError, BotoCoreError
+from boto3.dynamodb.conditions import Key
 from src.schemas.omamori import OmamoriInput, ShrineName
 from datetime import datetime
 from src.db.s3 import upload_picture, delete_picture_by_object_name
@@ -19,6 +20,19 @@ from src.utils.enum_types import UploadStatus, LocaleEnum
 # primary key is uuid
 
 omamori_table = dynamodb.Table("omamori")
+
+
+def get_omamori(prefecture: str):
+    try:
+        items_by_prefecture = omamori_table.query(
+            IndexName="prefecture_index",
+            Select="ALL_ATTRIBUTES",
+            KeyConditionExpression=Key("prefecture").eq(prefecture)
+        )
+        return items_by_prefecture["Items"]
+    except Exception as e:
+        print(f"Could not find items: {str(e)}")
+        return None
 
 
 def create_omamori(omamori: OmamoriInput):


### PR DESCRIPTION
# Description

In this PR I have added search functionality on `prefecture` or both `prefecture` and `protection`. To be able to search on `prefectures` I had to change the schema of our dynamodb table

# Closes issue(s)

Resolves #27 

# How to test

1. Start the server
2. Create an Omamori
3. Retrieve the omamori by `prefecture` and/or `protection`

# Changes include

1. Added query parameters to the route
2. Created Pydantic type so we validate our search result
3. Added Global Secondary Index to our dynamodb schema
4. Refactor how we create our dynamoddb table
5. Created a service that queries items on `prefecture` and `protection`

# To Do
- Add pagination on search result
- Add the ability to be able to return list of omamori without any filters
- If needed the functionality to also be able to search only on `protection`

# Checklist

- [x] I have tested this code
- [x] I have updated the README