### PR TITLE
feat: add pagination to to search_omamori

### DIFF
--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -12,15 +12,15 @@ async def search_omamori(
     prefecture: PrefectureEnum | None = None,
     protection: ProtectionTypeEnum | None = None,
     limit: int | None = 20,
-    primary_start_key: str | None = None,
-    sort_start_key: str | None = None
+    prefecture_start_key: str | None = None,
+    uuid_start_key: str | None = None
 ) -> OmamoriSearchResults:
     omamoris_by_prefecture = service.search_omamori(
         prefecture=prefecture,
         protection=protection,
         limit=limit,
-        primary_start_key=primary_start_key,
-        sort_start_key=sort_start_key
+        prefecture_start_key=prefecture_start_key,
+        uuid_start_key=uuid_start_key
     )
     return omamoris_by_prefecture
 

--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -6,15 +6,24 @@ from src.utils.enum_types import PrefectureEnum, ProtectionTypeEnum
 
 router = APIRouter()
 
+# -> OmamoriSearchResults
+
 
 @router.get("/omamori/")
 async def search_omamori(
     prefecture: PrefectureEnum | None = None,
     protection: ProtectionTypeEnum | None = None,
-    limit: int | None = 20
-) -> OmamoriSearchResults:
+    limit: int | None = 20,
+    primary_start_key: str | None = None,
+    sort_start_key: str | None = None
+):
     omamoris_by_prefecture = service.search_omamori(
-        prefecture=prefecture, protection=protection, limit=limit)
+        prefecture=prefecture,
+        protection=protection,
+        limit=limit,
+        primary_start_key=primary_start_key,
+        sort_start_key=sort_start_key
+    )
     return omamoris_by_prefecture
 
 

--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -6,8 +6,6 @@ from src.utils.enum_types import PrefectureEnum, ProtectionTypeEnum
 
 router = APIRouter()
 
-# -> OmamoriSearchResults
-
 
 @router.get("/omamori/")
 async def search_omamori(
@@ -16,7 +14,7 @@ async def search_omamori(
     limit: int | None = 20,
     primary_start_key: str | None = None,
     sort_start_key: str | None = None
-):
+) -> OmamoriSearchResults:
     omamoris_by_prefecture = service.search_omamori(
         prefecture=prefecture,
         protection=protection,

--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -11,9 +11,10 @@ router = APIRouter()
 async def search_omamori(
     prefecture: PrefectureEnum | None = None,
     protection: ProtectionTypeEnum | None = None,
-) -> list[OmamoriSearchResults]:
+    limit: int | None = 20
+) -> OmamoriSearchResults:
     omamoris_by_prefecture = service.search_omamori(
-        prefecture=prefecture, protection=protection)
+        prefecture=prefecture, protection=protection, limit=limit)
     return omamoris_by_prefecture
 
 

--- a/src/schemas/omamori.py
+++ b/src/schemas/omamori.py
@@ -43,3 +43,4 @@ class OmamoriQuery(OmamoriInput):
 class OmamoriSearchResults(BaseModel):
     omamoris: list[OmamoriQuery]
     last_evaluated_item: dict
+    total_results: int

--- a/src/schemas/omamori.py
+++ b/src/schemas/omamori.py
@@ -36,5 +36,10 @@ class OmamoriInput(BaseModel):
     upload_status: UploadStatus | None = UploadStatus.NOT_STARTED
 
 
-class OmamoriSearchResults(OmamoriInput):
+class OmamoriQuery(OmamoriInput):
     _upload_status: UploadStatus | None = UploadStatus.NOT_STARTED
+
+
+class OmamoriSearchResults(BaseModel):
+    omamoris: list[OmamoriQuery]
+    last_evaluated_item: dict

--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -1,6 +1,5 @@
 import logging
 import uuid
-import boto3
 from fastapi import UploadFile
 from botocore.exceptions import ClientError, BotoCoreError
 from src.schemas.omamori import OmamoriInput, ShrineName, OmamoriSearchResults
@@ -49,12 +48,16 @@ def search_omamori(
         if protection:
             expression_attributes_values[":prefecture_val"] = protection.value
 
-            search_query["FilterExpression"] = "protection_type = :protection_val"
+            search_query["FilterExpression"] = (
+                "protection_type = :protection_val"
+            )
 
         if prefecture:
             expression_attributes_values[":prefecture_val"] = prefecture.value
 
-            search_query["KeyConditionExpression"] = "prefecture = :prefecture_val"
+            search_query["KeyConditionExpression"] = (
+                "prefecture = :prefecture_val"
+            )
 
         omamori_search_result = OMAMORI_TABLE.query(**search_query)
 

--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -66,7 +66,7 @@ def search_omamori(
         return {
             "omamoris": omamori_search_result["Items"],
             "last_evaluated_item": last_evaluated_item,
-            "TotalResults": omamori_search_result["Count"]
+            "total_results": omamori_search_result["Count"]
         }
 
     except (ClientError) as err:

--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -25,8 +25,8 @@ def search_omamori(
     prefecture: PrefectureEnum | None,
     protection: ProtectionTypeEnum | None,
     limit: int,
-    primary_start_key: str,
-    sort_start_key: str
+    prefecture_start_key: str,
+    uuid_start_key: str
 ) -> OmamoriSearchResults:
     try:
 
@@ -38,10 +38,10 @@ def search_omamori(
             "ExpressionAttributeValues": expression_attributes_values,
         }
 
-        if primary_start_key and sort_start_key:
+        if prefecture_start_key and uuid_start_key:
             query_start_key = {
-                "prefecture": primary_start_key,
-                "uuid": sort_start_key
+                "prefecture": prefecture_start_key,
+                "uuid": uuid_start_key
             }
             search_query["ExclusiveStartKey"] = query_start_key
 


### PR DESCRIPTION
# Description

This PR introduces pagination to the `search_omamori` endpoint, allowing us to set a limit when retrieving omamori.

The response now includes two new fields:

- **`last_evaluated_item`**: Represents the last item returned in the paginated response. If additional omamori are needed beyond the first request, include this value in the query string to continue pagination from where it left off.
- **`total_results`**: Indicates the total number of omamori retrieved in the current request.

# Closes issue(s)

Resolves #48

# How to test

1. Start the server.
2. Create multiple omamori.
3. Make a `GET` request to `search_omamori` with a `limit` parameter set to `1`.
4. Verify that only one omamori is returned.
5. Check the response for `last_evaluated_item` and use its value in the next query to retrieve the next set of omamori.

# Changes include

- Refactored `search_query` to support dynamic queries.
- Updated response structure to include pagination metadata.
- Added support for query parameters to manage pagination.


# Checklist

- [x] I have tested this code
- [x] I have updated the README