### PR TITLE
fix: add prefecture to key attribute in upload_omamori_picture

### DIFF
--- a/src/routers/omamori.py
+++ b/src/routers/omamori.py
@@ -33,7 +33,11 @@ async def create_omamori(omamori: OmamoriInput) -> OmamoriOut:
 
 
 @router.post("/uploadpicture")
-async def upload_omamori_picture(picture: UploadFile, uuid: str = Form(...)):
+async def upload_omamori_picture(
+    picture: UploadFile,
+    uuid: str = Form(...),
+    prefecture: str = Form(...)
+):
     uploaded_picture = service.upload_omamori_picture(
-        img_file=picture, uuid=uuid)
+        img_file=picture, uuid=uuid, prefecture=prefecture)
     return uploaded_picture

--- a/src/service/omamori_service.py
+++ b/src/service/omamori_service.py
@@ -127,11 +127,12 @@ def create_omamori(omamori: OmamoriInput):
         )
 
 
-def upload_omamori_picture(img_file: UploadFile, uuid: str):
+def upload_omamori_picture(img_file: UploadFile, uuid: str, prefecture: str):
     try:
         existing_omamori = OMAMORI_TABLE.get_item(
             Key={
-                "uuid": uuid
+                "uuid": uuid,
+                "prefecture": prefecture
             }
         )
 
@@ -172,7 +173,8 @@ def upload_omamori_picture(img_file: UploadFile, uuid: str):
 
         updated_omamori = OMAMORI_TABLE.update_item(
             Key={
-                "uuid": uuid
+                "uuid": uuid,
+                "prefecture": prefecture
             },
             UpdateExpression=update_expression,
             ExpressionAttributeNames=expression_attribute_names,


### PR DESCRIPTION
# Description

In previous PR I have added `prefecture` as sort key. This means when we upload a picture, where an update and get happens, we need to include `prefecture` to the key since it's now part of the primary key.

# Closes issue(s)

Resolves #53 

# How to test

1. Start the server with your AWS credentials
2. Create a omamori
3. Use the prefecture and uuid of that omamori to make a request to `uploadpicture` route

# Changes include

1. Add `prefectute` to the request body in the `uploadpicture` route
2. Add `prefecture` to the key attribute in the `upload_omamori_picture`

# Checklist

- [ ] I have tested this code
- [ ] I have updated the README